### PR TITLE
Absolute magnitude patch

### DIFF
--- a/ugali/analysis/results.py
+++ b/ugali/analysis/results.py
@@ -237,12 +237,18 @@ class Results(object):
         lum = rich*stellar_luminosity
         lum_lo,lum_hi = rich_err[0]*stellar_luminosity,rich_err[1]*stellar_luminosity
         results['luminosity'] = ugali.utils.stats.interval(lum,lum_lo,lum_hi)
- 
-        Mv = self.source.absolute_magnitude(rich)
-        Mv_lo = self.source.absolute_magnitude(rich_err[0])
-        Mv_hi = self.source.absolute_magnitude(rich_err[1])
-        results['Mv'] = ugali.utils.stats.interval(Mv,Mv_lo,Mv_hi)
- 
+
+        # Absolute magnitude only calculated for DES isochrones with g,r 
+        try:
+            Mv = self.source.absolute_magnitude(rich)
+            Mv_lo = self.source.absolute_magnitude(rich_err[0])
+            Mv_hi = self.source.absolute_magnitude(rich_err[1])
+            results['Mv'] = ugali.utils.stats.interval(Mv,Mv_lo,Mv_hi)
+        except ValueError as e:
+            logger.warning("Skipping absolute magnitude")
+            logger.warn(str(e))
+            results['Mv'] = np.nan
+
         # ADW: WARNING this is very fragile.
         # Also, this is not quite right, should cut on the CMD available space
         kwargs = dict(richness=rich,mag_bright=16., mag_faint=23.,

--- a/ugali/isochrone/model.py
+++ b/ugali/isochrone/model.py
@@ -330,19 +330,19 @@ class IsochroneModel(Model):
         --------
         abs_mag : Absolute magnitude (Mv)
         """
-        # Using the SDSS g,r -> V from Jester 2005 [arXiv:0506022]
+        # Using the SDSS g,r -> V from Jester 2005 [astro-ph/0506022]
         # for stars with R-I < 1.15
         # V = g_sdss - 0.59(g_sdss-r_sdss) - 0.01
         # g_des = g_sdss - 0.104(g_sdss - r_sdss) + 0.01
         # r_des = r_sdss - 0.102(g_sdss - r_sdss) + 0.02
         if self.survey.lower() != 'des':
-            raise Exception('Only valid for DES')
+            raise ValueError('Absolute magnitude calculation only valid for DES')
         if 'g' not in [self.band_1,self.band_2]:
-            msg = "Need g-band for absolute magnitude"
-            raise Exception(msg)    
+            msg = "Need g-band for absolute magnitude calculation"
+            raise ValueError(msg)    
         if 'r' not in [self.band_1,self.band_2]:
-            msg = "Need r-band for absolute magnitude"
-            raise Exception(msg)    
+            msg = "Need r-band for absolute magnitude calculation"
+            raise ValueError(msg)    
 
         mass_init,mass_pdf,mass_act,mag_1,mag_2=self.sample(mass_steps = steps)
         g,r = (mag_1,mag_2) if self.band_1 == 'g' else (mag_2,mag_1)


### PR DESCRIPTION
This is a patch to allow the results to be created when the absolute magnitude calculation fails (as described in #56). The true fix (i.e. calculating the absolute magnitude for non-DES g,r isochrones) will be more involved.