### PR TITLE
Basestring

### DIFF
--- a/ugali/isochrone/composite.py
+++ b/ugali/isochrone/composite.py
@@ -129,6 +129,12 @@ class CompositeIsochrone(IsochroneModel):
     stellarLuminosity = stellar_luminosity
     observableFraction = observable_fraction
 
+    def absolute_magnitude(self, richness=1, steps=1e4):
+        raise ValueError("Not implemented for CompositeIsochrone")
+
+    def absolute_magnitude_martin(self, richness=1, steps=1e4):
+        raise ValueError("Not implemented for CompositeIsochrone")
+
 # ADW: It would be better if the factory were in isochrone.__init__
 # but then you get into a circular import situation with the
 # CompositeIsochrone. This is an unfortunate design decision...

--- a/ugali/isochrone/model.py
+++ b/ugali/isochrone/model.py
@@ -316,8 +316,10 @@ class IsochroneModel(Model):
     stellarMass = stellar_mass
     stellarLuminosity = stellar_luminosity
 
-    def absolute_magnitude(self, richness=1, steps=1e4):
+    def absolute_magnitude2(self, richness=1, steps=1e4):
         """
+        DEPRECATED: ADW 2018-08-30
+
         Calculate the absolute magnitude (Mv) by integrating the
         stellar luminosity.
 
@@ -352,20 +354,57 @@ class IsochroneModel(Model):
         Mv = -2.5*np.log10(richness*flux)
         return Mv
 
-    def absolute_magnitude_martin(self, richness=1, steps=1e4, n_trials=1000, mag_bright=16., mag_faint=23., alpha=0.32, seed=None):
+    def absolute_magnitude(self, richness=1, steps=1e4):
         """
+        Calculate the absolute magnitude (Mv) from the richness by
+        transforming the isochrone in the SDSS system and using the
+        g,r -> V transform equations from Jester 2005
+        [astro-ph/0506022].
+
+
+        Parameters:
+        -----------
+        richness : isochrone normalization parameter
+        steps    : number of isochrone sampling steps
+
+        Returns:
+        --------
+        abs_mag : Absolute magnitude (Mv)
+        """
+        # Using the SDSS g,r -> V from Jester 2005 [astro-ph/0506022]
+        # for stars with R-I < 1.15
+        # V = g_sdss - 0.59*(g_sdss - r_sdss) - 0.01
+
+        # Create a copy of the isochrone in the SDSS system
+        params = {k:v.value for k,v in self._params.items()}
+        params.update(band_1='g',band_2='r',survey='sdss')
+        iso = self.__class__(**params)
+
+        mass_init, mass_pdf, mass_act, g, r = iso.sample(mass_steps=steps)
+
+        V = g - 0.59*(g - r) - 0.01
+        flux = np.sum(mass_pdf*10**(-V/2.5))
+        Mv = -2.5*np.log10(richness*flux)
+        return Mv
+
+    def absolute_magnitude_martin2(self, richness=1, steps=1e4, n_trials=1000, mag_bright=16., mag_faint=23., alpha=0.32, seed=None):
+        """
+        DEPRECATED: 2018-08
+
         Calculate the absolute magnitude (Mv) of the isochrone using
         the prescription of Martin et al. 2008.
         
+        ADW: Seems like the faint and bright limits should depend on the survey maglime?
+
         Parameters:
         -----------
-        richness : Isochrone nomalization factor
-        steps : Number of steps for sampling the isochrone.
-        n_trials : Number of bootstrap samples
+        richness   : Isochrone nomalization factor
+        steps      : Number of steps for sampling the isochrone.
+        n_trials   : Number of bootstrap samples
         mag_bright : Bright magnitude limit for calculating luminosity.
-        mag_faint : Faint magnitude limit for calculating luminosity.
-        alpha : Output confidence interval (1-alpha)
-        seed : Random seed
+        mag_faint  : Faint magnitude limit for calculating luminosity.
+        alpha      : Output confidence interval (1-alpha)
+        seed       : Random seed
 
         Returns:
         --------
@@ -374,6 +413,8 @@ class IsochroneModel(Model):
         # ADW: This function is not quite right. You should be restricting
         # the catalog to the obsevable space (using the function named as such)
         # Also, this needs to be applied in each pixel individually
+        # ADW: This becomes even more complicated when we transform
+        # the isochrone into SDSS g,r.
         
         # Using the SDSS g,r -> V from Jester 2005 [arXiv:0506022]
         # for stars with R-I < 1.15
@@ -428,6 +469,81 @@ class IsochroneModel(Model):
         # ADW: Careful, fainter abs mag is larger (less negative) number
         q = [100*alpha/2., 50, 100*(1-alpha/2.)]
         hi,med,lo = np.percentile(abs_mag_obs_array,q)
+        return ugali.utils.stats.interval(med,lo,hi)
+
+    def absolute_magnitude_martin(self, richness=1, steps=1e4, n_trials=1000, mag_bright=None, mag_faint=23., alpha=0.32, seed=None):
+        """
+        Calculate the absolute magnitude (Mv) of the isochrone using
+        the prescription of Martin et al. 2008.
+        
+        ADW: Seems like the faint and bright limits should depend on the survey maglime?
+
+        Parameters:
+        -----------
+        richness   : Isochrone nomalization factor
+        steps      : Number of steps for sampling the isochrone.
+        n_trials   : Number of bootstrap samples
+        mag_bright : Bright magnitude limit [SDSS g-band] for luminosity calculation
+        mag_faint  : Faint magnitude limit [SDSS g-band] for luminosity calculation
+        alpha      : Output confidence interval (1-alpha)
+        seed       : Random seed
+
+        Returns:
+        --------
+        med,lo,hi : Absolute magnitude interval
+        """
+        # ADW: This function is not quite right. It should restrict
+        # the catalog to the obsevable space (using the function named
+        # as such). Also, this needs to be applied in each pixel
+        # individually. This becomes even more complicated when we
+        # transform the isochrone into SDSS g,r.
+        
+        # Using the SDSS g,r -> V from Jester 2005 [astro-ph/0506022]
+        # for stars with R-I < 1.15
+        # V = g_sdss - 0.59*(g_sdss - r_sdss) - 0.01
+        np.random.seed(seed)
+
+        # Create a copy of the isochrone in the SDSS system
+        params = {k:v.value for k,v in self._params.items()}
+        params.update(band_1='g',band_2='r',survey='sdss')
+        iso = self.__class__(**params)
+
+        mass_init, mass_pdf, mass_act, g, r = iso.sample(mass_steps=steps)
+
+        def visual(g, r, pdf=None):
+            # Calculate the visual absolute magnitude from g,r
+            V = g - 0.59*(g - r) - 0.01
+            if pdf is None:
+                flux = np.sum(10**(-V / 2.5))
+            else:
+                flux = np.sum(pdf * 10**(-V / 2.5))
+            abs_mag_v = -2.5 * np.log10(flux)
+            return abs_mag_v
+
+        def sumMag(mag_1, mag_2):
+            # Sum magnitudes by flux
+            flux_1 = 10**(-mag_1 / 2.5)
+            flux_2 = 10**(-mag_2 / 2.5)
+            return -2.5 * np.log10(flux_1 + flux_2)
+
+        # Analytic part (below detection threshold)
+        mass_init, mass_pdf, mass_act, g, r = iso.sample(mass_steps = steps)
+        cut = ((g + iso.distance_modulus) > mag_faint)
+        mag_unobs = visual(g[cut], r[cut], richness * mass_pdf[cut])
+
+        # Stochastic part (above detection threshold)
+        abs_mag = np.zeros(n_trials)
+        for i in range(n_trials):
+            if i%100==0: logger.debug('%i absolute magnitude trials'%i)
+            g, r = iso.simulate(richness * iso.stellar_mass())
+            cut = (g < mag_faint) 
+            mag_obs = visual(g[cut] - iso.distance_modulus, 
+                             r[cut] - iso.distance_modulus)
+            abs_mag[i] = sumMag(mag_obs, mag_unobs)
+
+        # ADW: Careful, fainter abs mag is larger (less negative) number
+        q = [100*alpha/2., 50, 100*(1-alpha/2.)]
+        hi,med,lo = np.percentile(abs_mag,q)
         return ugali.utils.stats.interval(med,lo,hi)
 
     def simulate(self, stellar_mass, distance_modulus=None, **kwargs):

--- a/ugali/isochrone/model.py
+++ b/ugali/isochrone/model.py
@@ -61,6 +61,12 @@ def get_iso_dir():
         logger.warning(msg)
     return isodir
 
+def sumMag(mag_1, mag_2):
+    """Sum two magnitudes in flux space."""
+    flux_1 = 10**(-mag_1 / 2.5)
+    flux_2 = 10**(-mag_2 / 2.5)
+    return -2.5 * np.log10(flux_1 + flux_2)
+
 class IsochroneModel(Model):
     """ Abstract base class for dealing with isochrone models. """
 
@@ -441,11 +447,6 @@ class IsochroneModel(Model):
             abs_mag_v = -2.5 * np.log10(flux)
             return abs_mag_v
 
-        def sumMag(mag_1, mag_2):
-            flux_1 = 10**(-mag_1 / 2.5)
-            flux_2 = 10**(-mag_2 / 2.5)
-            return -2.5 * np.log10(flux_1 + flux_2)
-
         # Analytic part
         mass_init, mass_pdf, mass_act, mag_1, mag_2 = self.sample(mass_steps = steps)
         g,r = (mag_1,mag_2) if self.band_1 == 'g' else (mag_2,mag_1)
@@ -476,7 +477,7 @@ class IsochroneModel(Model):
         Calculate the absolute magnitude (Mv) of the isochrone using
         the prescription of Martin et al. 2008.
         
-        ADW: Seems like the faint and bright limits should depend on the survey maglime?
+        ADW: Seems like the faint and bright limits should depend on the survey maglim?
 
         Parameters:
         -----------
@@ -493,10 +494,9 @@ class IsochroneModel(Model):
         med,lo,hi : Absolute magnitude interval
         """
         # ADW: This function is not quite right. It should restrict
-        # the catalog to the obsevable space (using the function named
-        # as such). Also, this needs to be applied in each pixel
-        # individually. This becomes even more complicated when we
-        # transform the isochrone into SDSS g,r.
+        # the catalog to the obsevable space using the mask in each
+        # pixel.  This becomes even more complicated when we transform
+        # the isochrone into SDSS g,r...
         
         # Using the SDSS g,r -> V from Jester 2005 [astro-ph/0506022]
         # for stars with R-I < 1.15
@@ -520,11 +520,6 @@ class IsochroneModel(Model):
             abs_mag_v = -2.5 * np.log10(flux)
             return abs_mag_v
 
-        def sumMag(mag_1, mag_2):
-            # Sum magnitudes by flux
-            flux_1 = 10**(-mag_1 / 2.5)
-            flux_2 = 10**(-mag_2 / 2.5)
-            return -2.5 * np.log10(flux_1 + flux_2)
 
         # Analytic part (below detection threshold)
         mass_init, mass_pdf, mass_act, g, r = iso.sample(mass_steps = steps)

--- a/ugali/utils/config.py
+++ b/ugali/utils/config.py
@@ -13,6 +13,7 @@ import healpy as hp
 
 from ugali.utils.logger import logger
 import ugali.utils.config # To recognize own type
+from ugali.utils.mlab import isstring
 
 try: import yaml
 except ImportError: logger.warning("YAML not found")
@@ -22,20 +23,20 @@ class Config(dict):
     Configuration object
     """
 
-    def __init__(self, input, default=None):
+    def __init__(self, config, default=None):
         """
         Initialize a configuration object from a filename or a dictionary.
         Provides functionality to merge with a default configuration.
 
         Parameters:
-          input:   Filename, dict, or Config (deep copied)
-          default: Default configuration to merge
+          config:   filename, dict, or Config object (deep copied)
+          default:  default configuration to merge
         
         Returns:
           config
         """
         self.update(self._load(default))
-        self.update(self._load(input))
+        self.update(self._load(config))
 
         self._formatFilepaths()
 
@@ -60,29 +61,27 @@ class Config(dict):
     def __str__(self):
         return yaml.dump(self)
 
-    def _load(self, input):
-        if isinstance(input, str):
-            self.filename = input
-            ext = os.path.splitext(input)[1]
-            if ext == '.py':
-                # ADW: This is dangerous and terrible!!!
-                # THIS SHOULD BE DEPRICATED!!!
-                msg = "Python configuration files are deprecated."
-                DeprecationWarning(msg)
-                reader = open(input)
-                params = eval(''.join(reader.readlines()))
-                reader.close()
-            elif ext == '.yaml':
-                params = yaml.load(open(input))
-            else:
-                raise Exception('Unrecognized config format: %s'%ext)
-        elif isinstance(input, Config):
+    def _load(self, config):
+        """ Load this config from an existing config 
+
+        Parameters:
+        -----------
+        config : filename, config object, or dict to load
+
+        Returns:
+        --------
+        params : configuration parameters
+        """
+        if isstring(config):
+            self.filename = config
+            params = yaml.load(open(config))
+        elif isinstance(config, Config):
             # This is the copy constructor...
-            self.filename = input.filename
-            params = copy.deepcopy(input)
-        elif isinstance(input, dict):
-            params = copy.deepcopy(input)
-        elif input is None:
+            self.filename = config.filename
+            params = copy.deepcopy(config)
+        elif isinstance(config, dict):
+            params = copy.deepcopy(config)
+        elif config is None:
             params = {}
         else:
             raise Exception('Unrecognized input')

--- a/ugali/utils/fileio.py
+++ b/ugali/utils/fileio.py
@@ -8,14 +8,14 @@ import shutil
 import os
 from collections import OrderedDict as odict
 import itertools
+import warnings
 
 import fitsio
 import numpy as np
 import healpy as hp
 
 from ugali.utils.logger import logger
-#import logging as logger
-import warnings
+from ugali.utils.mlab import isstring
 
 def read(filename,**kwargs):
     """ Read a generic input file into a recarray.
@@ -126,7 +126,7 @@ def load(args):
     return fitsio.read(infile,columns=columns)
 
 def load_infiles(infiles,columns=None,multiproc=False):
-    if isinstance(infiles,str):
+    if isstring(infiles):
         infiles = [infiles]
 
     logger.debug("Loading %s files..."%len(infiles))

--- a/ugali/utils/mlab.py
+++ b/ugali/utils/mlab.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 """
-Transplanted from matplotlib.mlab
+Python utilities.
 """
-
 import six
 import numpy as np
 
@@ -14,6 +13,10 @@ def iterable(obj):
         return False
     return True
 
+def isstring(obj):
+    """Python 2/3 compatible string check"""
+    return isinstance(obj, six.string_types)
+
 def rec_append_fields(rec, names, arrs, dtypes=None):
     """
     Return a new record array with field names populated with data
@@ -21,8 +24,7 @@ def rec_append_fields(rec, names, arrs, dtypes=None):
     *arrs* and *dtypes* do not have to be lists. They can just be the
     values themselves.
     """
-    if (not isinstance(names, six.string_types) and iterable(names)
-            and len(names) and isinstance(names[0], six.string_types)):
+    if (not isstring(names) and iterable(names) and len(names) and isstring(names[0])):
         if len(names) != len(arrs):
             raise ValueError("number of arrays do not match number of names")
     else:  # we have only 1 name and 1 array
@@ -48,8 +50,3 @@ def rec_append_fields(rec, names, arrs, dtypes=None):
     for name, arr in zip(names, arrs):
         newrec[name] = arr
     return newrec
-
-if __name__ == "__main__":
-    import argparse
-    parser = argparse.ArgumentParser(description=__doc__)
-    args = parser.parse_args()

--- a/ugali/utils/plotting.py
+++ b/ugali/utils/plotting.py
@@ -35,8 +35,8 @@ from ugali.utils.healpix import ang2pix, get_nside
 from ugali.utils.projector import mod2dist,gal2cel,cel2gal
 from ugali.utils.projector import sphere2image,image2sphere
 from ugali.utils.config import Config
-
 from ugali.utils.logger import logger
+from ugali.utils.mlab import isstring
 
 params = {
     #'backend': 'eps',
@@ -848,7 +848,7 @@ class SourcePlotter(BasePlotter):
 
     def drawMembersSpatial(self,data):
         ax = plt.gca()
-        if isinstance(data,str):
+        if isstring(data):
             filename = data
             data = fitsio.read(filename)
 
@@ -886,7 +886,7 @@ class SourcePlotter(BasePlotter):
 
     def drawMembersCMD(self,data):
         ax = plt.gca()
-        if isinstance(data,str):
+        if isstring(data):
             filename = data
             data = fitsio.read(filename)
 
@@ -1149,7 +1149,7 @@ def plotMembership(config, data=None, kernel=None, isochrone=None, **kwargs):
     from mpl_toolkits.axes_grid1 import make_axes_locatable
 
     config = ugali.utils.config.Config(config)
-    if isinstance(data,str):
+    if isstring(data):
         data,header = fitsio.read(data,header=True)
 
     defaults = dict(s=20,edgecolor='none',vmin=0,vmax=1,zorder=3)

--- a/ugali/utils/projector.py
+++ b/ugali/utils/projector.py
@@ -8,6 +8,7 @@ http://adsabs.harvard.edu/abs/2002A%26A...395.1077C
 import numpy as np
 
 from ugali.utils.logger import logger
+from ugali.utils.mlab import isstring
 
 ############################################################
 
@@ -385,9 +386,7 @@ def dec2hms(dec):
     MINUTE = 60.
     SECOND = 3600.
     
-    if isinstance(dec,str):
-        dec = float(dec)
-
+    dec = float(dec)
     fhour = dec*(HOUR/DEGREE)
     hour = int(fhour)
 
@@ -405,10 +404,8 @@ def dec2dms(dec):
     HOUR = 24.
     MINUTE = 60.
     SECOND = 3600.
-    
-    if isinstance(dec,str):
-        dec = float(dec)
 
+    dec = float(dec)
     sign = np.copysign(1.0,dec)
 
     fdeg = np.abs(dec)
@@ -434,7 +431,7 @@ def hms2dec(hms):
     MINUTE = 60.
     SECOND = 3600.
 
-    if isinstance(hms,str):
+    if isstring(hms):
         hour,minute,second = np.array(re.split('[hms]',hms))[:3].astype(float)
     else:
         hour,minute,second = hms.T
@@ -456,7 +453,7 @@ def dms2dec(dms):
     # can have its signbit set:
     # http://docs.scipy.org/doc/numpy-1.7.0/reference/c-api.coremath.html#NPY_NZERO
 
-    if isinstance(dms,str):
+    if isstring(dms):
         degree,minute,second = np.array(re.split('[dms]',hms))[:3].astype(float)
     else:
         degree,minute,second = dms.T


### PR DESCRIPTION
Use `six` to deal with the annoying Python 2/3 `basestring` vs `str`.