### PR TITLE
Fix iau naming

### DIFF
--- a/ugali/analysis/results.py
+++ b/ugali/analysis/results.py
@@ -271,7 +271,7 @@ class Results(object):
             results['constellation'] = ang2const(lon,lat,self.coordsys)[1]
         except:
             pass
-        results['iau'] = ugali.utils.projector.ang2iau(lon,lat)
+        results['iau'] = ugali.utils.projector.ang2iau(lon,lat,self.coordsys)
  
         coord = SkyCoord(ra*u.deg,dec*u.deg,distance=dist*u.kpc)
         results['ra_sex'] = str(coord.ra.to_string())


### PR DESCRIPTION
We forgot to update the call to `ang2iau` to explicitly take the coordinate system. This has been causing buggy IAU names. Closes #71.

Note that there are still issues in the `gal` coordinates printed in results.