### PR TITLE
Continuing to fix IAU naming

### DIFF
--- a/ugali/analysis/search.py
+++ b/ugali/analysis/search.py
@@ -327,18 +327,7 @@ class CandidateSearch(object):
 
         objs['NANNULUS']  = self.nannulus[pix].astype(int)
         objs['NINTERIOR'] = self.ninterior[pix].astype(int)
-
         objs['NAME'] = ang2iau(objs['RA'],objs['DEC'],coord='cel')
-
-        # Default name formatting
-        # http://cdsarc.u-strasbg.fr/ftp/pub/iau/
-        # http://cds.u-strasbg.fr/vizier/Dic/iau-spec.htx
-        #fmt = "J%(hour)02i%(hmin)04.1f%(deg)+03i%(dmin)02i"
-        #for obj,_ra,_dec in zip(objs,objs['RA'],objs['DEC']):
-        #    hms = dec2hms(_ra); dms = dec2dms(_dec)
-        #    params = dict(hour=hms[0],hmin=hms[1]+hms[2]/60.,
-        #                  deg=dms[0],dmin=dms[1]+dms[2]/60.)
-        #    obj['NAME'] = fmt%params
 
         out = recfuncs.merge_arrays([objs,objects],usemask=False,
                                     asrecarray=True,flatten=True)

--- a/ugali/analysis/search.py
+++ b/ugali/analysis/search.py
@@ -18,7 +18,7 @@ import scipy.ndimage as ndimage
 from ugali.utils.shell import mkdir, which
 from ugali.utils.logger import logger
 from ugali.utils.binning import reverseHistogram
-from ugali.utils.projector import Projector,gal2cel,cel2gal,dec2hms,dec2dms,mod2dist
+from ugali.utils.projector import Projector,gal2cel,cel2gal,ang2iau,mod2dist
 from ugali.utils import healpix, mlab
 from ugali.utils.healpix import pix2ang, ang2pix
 from ugali.candidate.associate import SourceCatalog, catalogFactory
@@ -328,15 +328,17 @@ class CandidateSearch(object):
         objs['NANNULUS']  = self.nannulus[pix].astype(int)
         objs['NINTERIOR'] = self.ninterior[pix].astype(int)
 
+        objs['NAME'] = ang2iau(objs['RA'],objs['DEC'],coord='cel')
+
         # Default name formatting
         # http://cdsarc.u-strasbg.fr/ftp/pub/iau/
         # http://cds.u-strasbg.fr/vizier/Dic/iau-spec.htx
-        fmt = "J%(hour)02i%(hmin)04.1f%(deg)+03i%(dmin)02i"
-        for obj,_ra,_dec in zip(objs,objs['RA'],objs['DEC']):
-            hms = dec2hms(_ra); dms = dec2dms(_dec)
-            params = dict(hour=hms[0],hmin=hms[1]+hms[2]/60.,
-                          deg=dms[0],dmin=dms[1]+dms[2]/60.)
-            obj['NAME'] = fmt%params
+        #fmt = "J%(hour)02i%(hmin)04.1f%(deg)+03i%(dmin)02i"
+        #for obj,_ra,_dec in zip(objs,objs['RA'],objs['DEC']):
+        #    hms = dec2hms(_ra); dms = dec2dms(_dec)
+        #    params = dict(hour=hms[0],hmin=hms[1]+hms[2]/60.,
+        #                  deg=dms[0],dmin=dms[1]+dms[2]/60.)
+        #    obj['NAME'] = fmt%params
 
         out = recfuncs.merge_arrays([objs,objects],usemask=False,
                                     asrecarray=True,flatten=True)

--- a/ugali/utils/projector.py
+++ b/ugali/utils/projector.py
@@ -379,7 +379,11 @@ def cel2gal_angle(ra,dec,angle,offset=1e-7):
 
 def dec2hms(dec):
     """
-    ADW: This should really be replaced by astropy
+    ADW: This should be replaced by astropy...
+
+    from astropy.coordinates import Angle
+    hms = Angle(dec*u.deg).hms
+    return (hms.h,hms.m,hms.s)
     """
     DEGREE = 360.
     HOUR = 24.
@@ -398,7 +402,11 @@ def dec2hms(dec):
 
 def dec2dms(dec):
     """
-    ADW: This should really be replaced by astropy
+    ADW: This should be replaced by astropy
+
+    from astropy.coordinates import Angle
+    dms = Angle(dec*u.deg).dms
+    return (dms.d,dms.m,dms.s)
     """
     DEGREE = 360.
     HOUR = 24.
@@ -516,8 +524,8 @@ def ang2iau(lon,lat,coord='gal'):
     Naming has precision of one minute: J{HH}{MM}+{DD}{MM}
 
     See:
-    http://cdsarc.u-strasbg.fr/ftp/pub/iau/
-    http://cds.u-strasbg.fr/vizier/Dic/iau-spec.htx
+    https://www.iau.org/public/themes/naming/
+    http://cdsweb.u-strasbg.fr/Dic/iau-spec.html
 
     Parameters
     ----------
@@ -553,7 +561,7 @@ def ang2iau(lon,lat,coord='gal'):
     if scalar: return iau[0]
     return np.array(iau)
 
-    
+
 def match(lon1, lat1, lon2, lat2, tol=None, nnearest=1):
     """
     Adapted from Eric Tollerud.

--- a/ugali/utils/projector.py
+++ b/ugali/utils/projector.py
@@ -511,9 +511,25 @@ def ang2const(lon,lat,coord='gal'):
     return const
 
 def ang2iau(lon,lat,coord='gal'):
+    """
+    Convert from coordinates to IAU naming convention.
+    Naming has precision of one minute: J{HH}{MM}+{DD}{MM}
+
+    See:
+    http://cdsarc.u-strasbg.fr/ftp/pub/iau/
+    http://cds.u-strasbg.fr/vizier/Dic/iau-spec.htx
+
+    Parameters
+    ----------
+    lon   : longitude (deg)
+    lat   : latitude (deg)
+    coord : coordinate system for lon/lat ['gal','cel']
+
+    Returns
+    -------
+    name  : name consistent with IAU convention
+    """
     # Default name formatting
-    # http://cdsarc.u-strasbg.fr/ftp/pub/iau/
-    # http://cds.u-strasbg.fr/vizier/Dic/iau-spec.htx
     fmt = "J%(hour)02i%(hmin)02i%(deg)+03.0f%(dmin)02i"
 
     scalar = np.isscalar(lon)
@@ -528,7 +544,6 @@ def ang2iau(lon,lat,coord='gal'):
         msg = "Unrecognized coordinate"
         raise Exception(msg)
 
-    x,y = np.radians([ra,dec])
     iau = []
     for _ra,_dec in zip(ra,dec):
         hms = dec2hms(_ra); dms = dec2dms(_dec)
@@ -536,7 +551,7 @@ def ang2iau(lon,lat,coord='gal'):
                       deg=dms[0],dmin=dms[1])
         iau.append(fmt%params)
     if scalar: return iau[0]
-    return iau
+    return np.array(iau)
 
     
 def match(lon1, lat1, lon2, lat2, tol=None, nnearest=1):

--- a/ugali/utils/projector.py
+++ b/ugali/utils/projector.py
@@ -416,7 +416,8 @@ def dec2dms(dec):
     
     second = (fminute - minute)*MINUTE
 
-    deg = int(deg * sign)
+    # Careful, need float to allow negative zeros
+    deg = sign*int(deg)
     return (deg, minute, second)
 
 def hms2dec(hms):
@@ -513,7 +514,7 @@ def ang2iau(lon,lat,coord='gal'):
     # Default name formatting
     # http://cdsarc.u-strasbg.fr/ftp/pub/iau/
     # http://cds.u-strasbg.fr/vizier/Dic/iau-spec.htx
-    fmt = "J%(hour)02i%(hmin)02i%(deg)+03i%(dmin)02i"
+    fmt = "J%(hour)02i%(hmin)02i%(deg)+03.0f%(dmin)02i"
 
     scalar = np.isscalar(lon)
     lon = np.array(lon,copy=False,ndmin=1)


### PR DESCRIPTION
This PR fixes the sign of the IAU name for objects with 0 > DEC > -1. It also updates the search module to use consistent IAU names.