### PR TITLE
Update results.py to use azimuthally averaged half-light radius in surface brightness calculation (re issue 78)

### DIFF
--- a/ugali/analysis/results.py
+++ b/ugali/analysis/results.py
@@ -264,7 +264,7 @@ class Results(object):
             logger.warning("Skipping Martin magnitude")
             results['Mv_martin'] = np.nan
         
-        mu = surfaceBrightness(Mv, size, dist)
+        mu = surfaceBrightness(Mv, rsize, dist) ##updated from size-->rsize
         results['surface_brightness'] = ugali.utils.stats.interval(mu,np.nan,np.nan)
  
         try: 


### PR DESCRIPTION
Changed size --> rsize in surface brightness calc. in order to make this surface brightness within azimuthally averaged half-light radius