### PR TITLE
Compute extension_radial posterior directly and use this for parameter estimates, as opposed to using extension+ellipticity summary statistics 

### DIFF
--- a/ugali/analysis/results.py
+++ b/ugali/analysis/results.py
@@ -166,6 +166,8 @@ class Results(object):
             results['dec'] = self.estimate('dec',**kwargs)
             results['glon'] = self.estimate('glon',**kwargs)
             results['glat'] = self.estimate('glat',**kwargs)
+            results['extension_radial'] = self.estimate('extension_radial', **kwargs)
+            
         except KeyError:
             logger.warn("Didn't find 'ra' or 'dec' in Samples...")
             if self.coordsys == 'gal':
@@ -216,9 +218,9 @@ class Results(object):
  
         # Radially symmetric extension (correct for ellipticity).
         ell,ell_err = estimate['ellipticity']
-        rext,rext_err = ext*np.sqrt(1-ell),np.array(ext_err)*np.sqrt(1-ell)
+        rext,rext_err = results['extension_radial'] #ext*np.sqrt(1-ell),np.array(ext_err)*np.sqrt(1-ell)
         rext_sigma = np.nan_to_num(np.array(rext_err) - rext)
-        results['extension_radial'] = ugali.utils.stats.interval(rext,rext_err[0],rext_err[1])
+        #results['extension_radial'] = ugali.utils.stats.interval(rext,rext_err[0],rext_err[1]) # now obsolete
         results['extension_radial_arcmin'] = ugali.utils.stats.interval(60*rext,60*rext_err[0],60*rext_err[1])
  
         # Bayes factor for ellipticity

--- a/ugali/utils/stats.py
+++ b/ugali/utils/stats.py
@@ -299,7 +299,14 @@ class Samples(np.recarray):
                 names = ['position_angle_gal','position_angle_cel']
                 arrs = [pa_gal,pa_cel]
                 out = recfuncs.append_fields(out,names,arrs,**kwargs).view(Samples)
-        
+
+            if ('extension' in out.names) and ('ellipticity' in out.names):
+                ext = out.extension
+                ellipticity = out.ellipticity
+                rext = ext * np.sqrt(1-ellipticity)
+
+                out = recfuncs.append_fields(out,['extension_radial'], [rext]).view(Samples)
+                
         return out
 
     def get(self, names=None, burn=None, clip=None):


### PR DESCRIPTION
Compute extension_radial posterior directly and use this for parameter estimates, as opposed to using extension+ellipticity summary statistics.

Two part solution - first, add storage of extension_radial samples to ugali.utils.stats's Samples class, and then add handling of results in ugali.analysis.results