### PR TITLE
Add LSST R1.9, Roman, and Euclid support to PARSEC isochrones

### DIFF
--- a/ugali/isochrone/parsec.py
+++ b/ugali/isochrone/parsec.py
@@ -164,8 +164,9 @@ defaults_33 = {'cmd_version': 3.3,
                }
 
 defaults_36 = dict(defaults_33,cmd_version=3.6)
-defaults_38 = dict(defaults_33,cmd_version=3.8)
 defaults_39 = dict(defaults_33,cmd_version=3.9)
+
+
 class ParsecIsochrone(Isochrone):
     """ Base class for PARSEC-style isochrones. """
 

--- a/ugali/isochrone/parsec.py
+++ b/ugali/isochrone/parsec.py
@@ -565,7 +565,7 @@ class Marigo2017(ParsecIsochrone):
         self.data = np.genfromtxt(filename,**kwargs)
         # cut out anomalous point:
         # https://github.com/DarkEnergySurvey/ugali/issues/29
-        self.data = self.data[~np.in1d(self.data['stage'], [9])]
+        self.data = self.data[~np.isin(self.data['stage'], [9])]
 
         self.mass_init = self.data['mass_init']
         self.mass_act  = self.data['mass_act']

--- a/ugali/isochrone/parsec.py
+++ b/ugali/isochrone/parsec.py
@@ -35,6 +35,9 @@ photsys_dict = odict([
         ('acs_wfc' ,'tab_mag_odfnew/tab_mag_acs_wfc.dat'),
         ('lsst', 'tab_mag_odfnew/tab_mag_lsst.dat'),
         ('lsst_dp0', 'tab_mag_odfnew/tab_mag_lsstDP0.dat'),
+        ('lsst_r1p9', 'tab_mag_odfnew/tab_mag_lsstR1.9.dat'),
+        ('roman', 'tab_mag_odfnew/tab_mag_Roman2021.dat'),
+        ('euclid', 'tab_mag_odfnew/tab_mag_euclid_nisp.dat'),
 ])
 
 photname_dict = odict([
@@ -44,6 +47,9 @@ photname_dict = odict([
         ('acs_wfc','HST/ACS'),
         ('lsst', 'LSST'),
         ('lsst_dp0', 'LSST'),
+        ('lsst_r1p9', 'LSST'),
+        ('roman', 'Roman'),
+        ('euclid', 'Euclid'),
 ])
 
 # Commented options may need to be restored for older version/isochrones.
@@ -158,7 +164,8 @@ defaults_33 = {'cmd_version': 3.3,
                }
 
 defaults_36 = dict(defaults_33,cmd_version=3.6)
-
+defaults_38 = dict(defaults_33,cmd_version=3.8)
+defaults_39 = dict(defaults_33,cmd_version=3.9)
 class ParsecIsochrone(Isochrone):
     """ Base class for PARSEC-style isochrones. """
 
@@ -451,7 +458,7 @@ class Marigo2017(ParsecIsochrone):
         ('hb_spread',0.1,'Intrinisic spread added to horizontal branch'),
         )
 
-    download_defaults = copy.deepcopy(defaults_36)
+    download_defaults = copy.deepcopy(defaults_39)
     download_defaults['isoc_kind'] = 'parsec_CAF09_v1.2S_NOV13'
 
     columns = dict(
@@ -502,8 +509,33 @@ class Marigo2017(ParsecIsochrone):
                 (29,('z',float)),
                 (30,('Y',float)),
                 ]),
+        roman = odict([
+                (3, ('mass_init',float)),
+                (5, ('mass_act',float)),
+                (6, ('log_lum',float)),
+                (9,('stage',float)),
+                (25, ('F062',float)),
+                (26,('F087',float)),
+                (27,('F106',float)),
+                (28,('F129',float)),
+                (29,('F158',float)),
+                (30,('F184',float)),
+                (31,('F146',float)),
+                (32,('F213',float)),
+                ]),
+        euclid = odict([
+                (3, ('mass_init',float)),
+                (5, ('mass_act',float)),
+                (6, ('log_lum',float)),
+                (9,('stage',float)),
+                (25, ('VIS',float)),
+                (26,('Y',float)),
+                (28,('J',float)),
+                (30,('H',float)),
+                ]),
         )
     columns['lsst'] = copy.deepcopy(columns['lsst_dp0'])
+    columns['lsst_r1p9'] = copy.deepcopy(columns['lsst_dp0'])
 
     def _find_column_numbers(self):
         """ Map from the isochrone column names to the column numbers. """


### PR DESCRIPTION
This introduces support for more surveys ( LSST, Roman, and Euclid photometric systems) in the PARSEC isochrone module.
 And, a changes a np.in1d call to np.isin